### PR TITLE
Updating GCMConnection so it uses the api key in an authorization header

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -11,4 +11,4 @@ Lead
 Contributors
 ------------
 
-- None
+- Brad Montgomery, `bradmontgomery@github <https://github.com/bradmontgomery>`_

--- a/pushjack/gcm.py
+++ b/pushjack/gcm.py
@@ -115,8 +115,8 @@ class GCMConnection(object):
         self.url = url
 
         self.session = requests.Session()
-        self.session.auth = ('key', self.api_key)
         self.session.headers.update({
+            'Authorization': 'key={0}'.format(self.api_key),
             'Content-Type': 'application/json',
         })
 

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -149,19 +149,24 @@ def test_gcm_invalid_api_key(gcm_client):
         gcm_client.send('abc', {})
 
 
-@parametrize('tokens,data,extra,expected', [
+@parametrize('tokens,data,extra,auth,expected', [
     ('abc',
      {},
      {},
+     mock.call().headers.update({'Authorization': 'key=1234',
+                                 'Content-Type': 'application/json'}),
      mock.call().post('https://android.googleapis.com/gcm/send',
                       b'{"data":{},"registration_ids":["abc"]}')),
     (['abc'],
      {},
      {},
+     mock.call().headers.update({'Authorization': 'key=1234',
+                                 'Content-Type': 'application/json'}),
      mock.call().post('https://android.googleapis.com/gcm/send',
                       b'{"data":{},"registration_ids":["abc"]}'))
 ])
-def test_gcm_connection_call(gcm_client, tokens, data, extra, expected):
+def test_gcm_connection_call(gcm_client, tokens, data, extra, auth, expected):
     with mock.patch('requests.Session') as Session:
         gcm_client.send(tokens, data, **extra)
+        assert auth in Session.mock_calls
         assert expected in Session.mock_calls


### PR DESCRIPTION
This is the PR for #11. The test suite for the apn modules failed for me, but the gcm-related tests pass.

Let me know what you think.