### PR TITLE
Allow empty push notification.

### DIFF
--- a/pushjack/__meta__.py
+++ b/pushjack/__meta__.py
@@ -6,7 +6,7 @@ __title__ = 'pushjack'
 __summary__ = 'Push notifications for APNS (iOS) and GCM (Android).'
 __url__ = 'https://github.com/dgilland/pushjack'
 
-__version__ = '1.2.0'
+__version__ = '1.2.1'
 
 __install_requires__ = ['requests']
 

--- a/pushjack/apns.py
+++ b/pushjack/apns.py
@@ -509,11 +509,7 @@ class APNSMessage(object):
 
     def __len__(self):
         """Return length of serialized message."""
-        if not self.to_dict():
-            # Consider message length 0 if there is no message data.
-            return 0
-        else:
-            return len(self.to_json())
+        return len(self.to_json())
 
 
 class APNSMessageStream(object):
@@ -763,9 +759,6 @@ def validate_tokens(tokens):
 
 def validate_message(message):
     """Check whether `message` is valid."""
-    if len(message) == 0:
-        raise APNSMissingPayloadError('Notification body size cannot be 0')
-
     if len(message) > APNS_MAX_NOTIFICATION_SIZE:
         raise APNSInvalidPayloadSizeError(
             ('Notification body cannot exceed '

--- a/pushjack/apns.py
+++ b/pushjack/apns.py
@@ -501,10 +501,6 @@ class APNSMessage(object):
             'content-available': 1 if self.content_available else None
         })
 
-        if not message['aps']:
-            # Don't include 'aps' field if empty.
-            del message['aps']
-
         return message
 
     def to_json(self):

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -179,7 +179,6 @@ def test_apns_socket_write(apns_client, apns_socket):
 
 @parametrize('exception,alert', [
     (exceptions.APNSInvalidPayloadSizeError, '_' * 2049),
-    (exceptions.APNSMissingPayloadError, None)
 ])
 def test_apns_invalid_payload_size(apns_client, exception, alert):
     with mock.patch('pushjack.apns.APNSMessageStream.pack') as pack_frame:


### PR DESCRIPTION
There is a difference between empty payload and empty push notification. Empty payload would be if `APNSMessage.to_dict` return `{}`. Empty push notification would be if `APNSMessage.to_dict` return `{"aps": {}}`.

This change makes sure that __at least__ an empty push notification (if no params are passed). This is required for Passbook push notifications.

It also makes the usage consistent with documentation which says: "Set to `None` to send an empty alert notification."

Tests pass and coverage should remain 100%.