### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Links
 =====
 
 - Project: https://github.com/dgilland/pushjack
-- Documentation: http://pushjack.readthedocs.org
+- Documentation: https://pushjack.readthedocs.io
 - PyPi: https://pypi.python.org/pypi/pushjack/
 - TravisCI: https://travis-ci.org/dgilland/pushjack
 
@@ -203,7 +203,7 @@ Access response data.
     res.canonical_ids
 
 
-For more details, please see the full documentation at http://pushjack.readthedocs.org.
+For more details, please see the full documentation at https://pushjack.readthedocs.io.
 
 
 .. |version| image:: http://img.shields.io/pypi/v/pushjack.svg?style=flat-square

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -204,7 +204,7 @@ To enable logging using a configuration approach:
         }
     })
 
-For additional configuration options, you may wish to install `logconfig <http://logconfig.readthedocs.org/>`_:
+For additional configuration options, you may wish to install `logconfig <https://logconfig.readthedocs.io/>`_:
 
 ::
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ Push notifications for APNS (iOS) and GCM (Android).
 
 Project: https://github.com/dgilland/pushjack
 
-Documentation: http://pushjack.readthedocs.org/
+Documentation: https://pushjack.readthedocs.io/
 """
 
 import os


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
