### PR TITLE
Use FCM URL instead of deprecated GCM URL.

### DIFF
--- a/pushjack/gcm.py
+++ b/pushjack/gcm.py
@@ -36,7 +36,7 @@ __all__ = (
 log = logging.getLogger(__name__)
 
 
-GCM_URL = 'https://android.googleapis.com/gcm/send'
+GCM_URL = 'https://fcm.googleapis.com/fcm/send'
 
 # GCM only allows up to 1000 reg ids per bulk message.
 GCM_MAX_RECIPIENTS = 1000

--- a/tests/test_gcm.py
+++ b/tests/test_gcm.py
@@ -184,14 +184,14 @@ def test_gcm_invalid_api_key(gcm_client):
      {},
      mock.call().headers.update({'Authorization': 'key=1234',
                                  'Content-Type': 'application/json'}),
-     mock.call().post('https://android.googleapis.com/gcm/send',
+     mock.call().post('https://fcm.googleapis.com/fcm/send',
                       b'{"data":{},"priority":"high","to":"abc"}')),
     (['abc'],
      {},
      {},
      mock.call().headers.update({'Authorization': 'key=1234',
                                  'Content-Type': 'application/json'}),
-     mock.call().post('https://android.googleapis.com/gcm/send',
+     mock.call().post('https://fcm.googleapis.com/fcm/send',
                       b'{"data":{},"priority":"high","to":"abc"}'))
 ])
 def test_gcm_connection_call(gcm_client, tokens, data, extra, auth, expected):


### PR DESCRIPTION
According to https://developers.google.com/cloud-messaging/faq, "[...] you
don't need to update your sending logic for the migration. You'll only need
to update the server endpoint as described in the migration guide.".