### PR TITLE
Remove version flag, default to `ssl.PROTOCOL_TLS`

### DIFF
--- a/src/pushjack/apns.py
+++ b/src/pushjack/apns.py
@@ -775,11 +775,7 @@ def create_socket(host, port, certificate):
 
     sock = socket.socket()
 
-    # For some reason, pylint on TravisCI's Python 2.7 platform complains that
-    # ssl.PROTOCOL_TLSv1 doesn't exist. Add a disable flag to bypass this.
-    # pylint: disable=no-member
     sock = ssl.wrap_socket(sock,
-                           ssl_version=ssl.PROTOCOL_TLSv1,
                            certfile=certificate,
                            do_handshake_on_connect=False)
     sock.connect((host, port))

--- a/tests/test_apns.py
+++ b/tests/test_apns.py
@@ -258,8 +258,7 @@ def test_apns_create_socket(tmpdir):
 
         assert wrap_socket.called
 
-        expected = {'ssl_version': 3,
-                    'certfile': str(certificate),
+        expected = {'certfile': str(certificate),
                     'do_handshake_on_connect': False}
 
         assert wrap_socket.mock_calls[0][2] == expected


### PR DESCRIPTION
Fixes #40 

## Motivation
See #40. This flag has been deprecated, and prevents pushjack from using TLSv1.2, which is now required for APNS communication.