### PR TITLE
Add token-based APNs client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ Install using pip:
 Whether using ``APNS`` or ``GCM``, pushjack provides clients for each.
 
 
-APNS
-----
+APNS (using certificates)
+-------------------------
 
 Send notifications using the ``APNSClient`` class:
 
@@ -122,6 +122,51 @@ For the APNS sandbox, use ``APNSSandboxClient`` instead:
 .. code-block:: python
 
     from pushjack import APNSSandboxClient
+
+APNS (using Auth tokens)
+------------------------
+
+Send notifications using the ``APNSHTTP2Client`` class:
+
+
+.. code-block:: python
+
+    from pushjack import APNSHTTP2Client
+
+    key = "my_key"
+
+    token = apns.APNSAuthToken(
+        token=key,
+        team_id="my_team_id",
+        key_id="my_key_id",
+    )
+
+    client = apns.APNSHTTP2Client(
+        token=token,
+        bundle_id='my_bundle_id',
+    )
+
+    response = client.send_message(
+        device_id="my_device_id",
+        message="message",
+        content_available=True,
+        title="title"
+    )
+
+
+Close APNS connection.
+
+.. code-block:: python
+
+    client.conn.close()
+
+
+For the APNS sandbox, use ``APNSHTTP2SandboxClient`` instead:
+
+
+.. code-block:: python
+
+    from pushjack import APNSHTTP2SandboxClient
 
 
 GCM

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,8 @@ classifiers =
 [options]
 install_requires =
     requests
+    PyJWT
+    hyper
 
 [options.extras_require]
 dev =

--- a/src/pushjack/__init__.py
+++ b/src/pushjack/__init__.py
@@ -9,6 +9,8 @@ from .apns import (
     APNSSandboxClient,
     APNSResponse,
     APNSExpiredToken,
+    APNSHTTP2Client,
+    APNSHTTP2SandboxClient,
 )
 
 from .gcm import (

--- a/src/pushjack/exceptions.py
+++ b/src/pushjack/exceptions.py
@@ -72,6 +72,13 @@ class APNSError(NotificationError):
     pass
 
 
+class APNSMessagePartiallySentError(APNSError):
+    """
+    Messages are partially sent out.
+    """
+    description = 'Not all messages are sent'
+
+
 class APNSAuthError(APNSError):
     """Exception with APNS certificate."""
     pass


### PR DESCRIPTION
Prior to this commit, all APNs communication was certificate-based.

This commit brings a token-based APNs client for sending push
notifications.

The token-based client:
- requires the app bundle id to be provided
- has a method for sending using a p8 Auth key file
- has a method for sending using the raw key value
- has the ability to send messages in bulk